### PR TITLE
fix: add .gitattributes to enforce LF line endings (closes #7)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Ensure shell scripts always use LF line endings
+*.sh text eol=lf
+
+# Other common files that should use LF
+*.bash text eol=lf
+Dockerfile text eol=lf


### PR DESCRIPTION
Fixes #7

## Problem
When cloning and running `docker-compose up --build` on Windows, the prestart and frontend containers fail due to CRLF line endings in shell scripts.

## Solution
Added `.gitattributes` to enforce LF line endings for all shell scripts. This ensures that when users clone the repository, Git will automatically normalize line endings to LF.

## Files Changed
- `.gitattributes` (new)

## Testing
Tested on Windows 11 with Docker Desktop v29.1.3 - the `.gitattributes` configuration correctly enforces LF line endings.